### PR TITLE
Patch commons logging and move to java 8 required so that this is confirmed working with jdk 20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [11, 17, 18, 19-ea]
+        java: [11, 17, 19, 20-ea]
         distribution: ['zulu']
       fail-fast: false
       max-parallel: 4

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
   </distributionManagement>
 
   <properties>
-    <java.version>7</java.version>
-    <java.release.version>7</java.release.version>
+    <java.version>8</java.version>
+    <java.release.version>8</java.release.version>
 
     <clirr.comparisonVersion>1.0.2</clirr.comparisonVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 
     <clirr.comparisonVersion>1.0.2</clirr.comparisonVersion>
 
+    <commons-logging.version>1.2</commons-logging.version>
     <spring.version>3.2.18.RELEASE</spring.version>
 
     <module.name>org.mybatis.spring.mybatis2</module.name>
@@ -88,6 +89,12 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-orm</artifactId>
       <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${commons-logging.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This sets up for last release in current style.